### PR TITLE
Add WordPress plugin: JAMstack Deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ List of useful plugins to make WordPress and Gatsby work together.
 - [WPGraphQL Gutenberg](https://github.com/pristas-peter/wp-graphql-gutenberg)
 - [WPGraphQL Gutenberg ACF](https://github.com/pristas-peter/wp-graphql-gutenberg-acf)
 - [WP API Menus](https://wordpress.org/plugins/wp-api-menus/)
+- [WP JAMstack Deployments](https://github.com/crgeary/wp-jamstack-deployments)
 
 
 **The obvious, that goes along with some of the plugins above:**


### PR DESCRIPTION
Title: WP JAMstack Deployments
Link: https://github.com/crgeary/wp-jamstack-deployments
Date: 02/06/2018

There are currently no solutions in the current list to trigger builds when you change content within WordPress. I built a plugin [for Gatsby users](https://github.com/gatsbyjs/gatsby/issues/2753#issuecomment-394109510) (although works with other tools too) that will notify services like Netlify (and others) when content is changed.